### PR TITLE
fix: make TransferAdapter & TransformationAdapter functions payable

### DIFF
--- a/abis/TransformationAdapter.json
+++ b/abis/TransformationAdapter.json
@@ -40,7 +40,7 @@
     ],
     "name": "returnERC1155",
     "outputs": [],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -53,7 +53,7 @@
     ],
     "name": "returnERC20",
     "outputs": [],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -71,7 +71,7 @@
     ],
     "name": "returnERC721",
     "outputs": [],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -213,7 +213,7 @@
     ],
     "name": "transferERC1155From",
     "outputs": [],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -246,7 +246,7 @@
     ],
     "name": "transferERC20From",
     "outputs": [],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -279,7 +279,7 @@
     ],
     "name": "transferERC721From",
     "outputs": [],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -297,7 +297,7 @@
     ],
     "name": "unwrapNativeToken",
     "outputs": [],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {

--- a/contracts/shoyu/adapters/Transfer/TransferAdapter.sol
+++ b/contracts/shoyu/adapters/Transfer/TransferAdapter.sol
@@ -25,7 +25,7 @@ contract TransferAdapter is ConduitAdapter {
         uint256 amount,
         TokenSource source,
         bytes memory data
-    ) public {
+    ) public payable {
         if (source == TokenSource.WALLET) {
             ERC20(token).transferFrom(msg.sender, to, amount);
         } else if (source == TokenSource.CONDUIT) {
@@ -56,7 +56,7 @@ contract TransferAdapter is ConduitAdapter {
         uint256 tokenId,
         TokenSource source,
         bytes memory data
-    ) public {
+    ) public payable {
         if (source == TokenSource.WALLET) {
             ERC721(token).safeTransferFrom(
                 msg.sender,
@@ -93,7 +93,7 @@ contract TransferAdapter is ConduitAdapter {
         uint256 amount,
         TokenSource source,
         bytes memory data
-    ) public {
+    ) public payable {
         if (source == TokenSource.WALLET) {
             ERC1155(token).safeTransferFrom(
                 msg.sender,
@@ -119,7 +119,7 @@ contract TransferAdapter is ConduitAdapter {
     /// @dev Function to return any excess ERC20 tokens from address(this)
     ///      to `msg.sender`.
     /// @param token        The token to return to the caller.
-    function returnERC20(address token) external {
+    function returnERC20(address token) external payable {
         uint256 balance = ERC20(token).balanceOf(address(this));
         if (balance > 0) {
             ERC20(token).transfer(msg.sender, balance);
@@ -130,7 +130,7 @@ contract TransferAdapter is ConduitAdapter {
     ///      address(this) to `msg.sender`.
     /// @param token        The token to return to the caller.
     /// @param tokenId      The token identifier of the asset.
-    function returnERC721(address token, uint256 tokenId) external {
+    function returnERC721(address token, uint256 tokenId) external payable {
         if (ERC721(token).ownerOf(tokenId) == address(this)) {
             ERC721(token).transferFrom(address(this), msg.sender, tokenId);
         }
@@ -140,7 +140,7 @@ contract TransferAdapter is ConduitAdapter {
     ///      address(this) to `msg.sender`.
     /// @param token        The token to return to the caller.
     /// @param tokenId      The token identifier of the asset.
-    function returnERC1155(address token, uint256 tokenId) external {
+    function returnERC1155(address token, uint256 tokenId) external payable {
         uint256 balance = ERC1155(token).balanceOf(address(this), tokenId);
         if (balance > 0) {
             ERC1155(token).safeTransferFrom(

--- a/contracts/shoyu/adapters/Transform/TransformationAdapter.sol
+++ b/contracts/shoyu/adapters/Transform/TransformationAdapter.sol
@@ -122,8 +122,9 @@ contract TransformationAdapter is LegacySwapAdapter {
     function unwrapNativeToken(
         uint256 amount,
         address payable to
-    ) public {
+    ) public payable {
         IWETH(WETH).withdraw(amount);
+
         if (to != address(this)) {
             to.transfer(amount);
         }


### PR DESCRIPTION
Because adapter functions are called via `delegatecall`, there are several cases where `msg.value` is greater than 0, requiring `payable`  modifier to be used.

For example, say a user wants to buy an NFT from a Seaport order that is listed in ETH and wants to pay using a combination of WETH and ETH. ETH will be sent to the Shoyu contract on invocation of the `cook` function. The WETH is then transferred from the buyer and unwrapped before attempting to fulfill the order.

In this case, even though the functions that transfer and unwrap the WETH don't need to receive ether, they will be invoked with `msg.value > 0`.